### PR TITLE
Add stops by route endpoint

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -65,4 +65,4 @@ const filterByDirection = (data, type, direction) => {
   return { header: data.header, entity: filtered };
 }
 
-module.exports = { filterByRoutes, filterByDirection }
+module.exports = { filterByRoutes, filterByDirection, isValidRouteId }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,9 @@ const path = require('path');
 const _ = require('lodash');
 const filterByRoutes = require('./filters').filterByRoutes;
 const filterByDirection = require('./filters').filterByDirection;
+const isValidRouteId = require('./filters').isValidRouteId;
 const stopsSortedByDistance = require('./sorted-stops').stopsSortedByDistance;
+const getStopsByRouteId = require('./stop-helpers.js').getStopsByRouteId;
 const port = process.env.PORT || 3000;
 const riptaApiBaseUrl = 'http://realtime.ripta.com:81/api/';
 //const riptaApiBaseUrl = 'http://localhost:3000/static/';
@@ -40,8 +42,19 @@ app.get('/api/stops?', (req, res) => {
       stopsWithDistances = stopsWithDistances.slice(0, parseInt(limit));
     }
 
-   res.json(stopsWithDistances);
+    res.json(stopsWithDistances);
   } else {
+    res.sendStatus(422);
+  }
+});
+
+app.get('/api/route/:route_id/stops', (req, res) => {
+  const routeId = req.params.route_id;
+  if (isValidRouteId(routeId)) {
+    const stops = getStopsByRouteId(routeId);
+    res.json(stops);
+  }
+  else {
     res.sendStatus(422);
   }
 });

--- a/stop-helpers.js
+++ b/stop-helpers.js
@@ -1,0 +1,13 @@
+'use strict';
+const _ = require('lodash');
+
+const stops = require('./static/stops.json');
+
+const getStopsByRouteId = (routeId) => {
+  routeId = parseInt(routeId, 10)
+  return _.filter(stops, (stop) => {
+    return (_.includes(stop.route_ids, routeId));
+  });
+}
+
+module.exports = { getStopsByRouteId };


### PR DESCRIPTION
Given a route id, API will return an array of stops objects.

`api/route/:route_id/stops`

Example:
`api/route/95/stops`

Returns
```
 [
  {
    "stop_id": "5",
    "stop_name": "WESTERLY TOWN HALL",
    "stop_lat": "41.377",
    "stop_lon": "-71.829771",
    "route_ids": [95]
  },
  {
    "stop_id": "10",
    "stop_name": "GROVE NS WILCOX",
    "stop_lat": "41.378328",
    "stop_lon": "-71.82668",
    "route_ids": [95]
  },
 .
 .
 .
] 