### PR TITLE
Fix direction_id type

### DIFF
--- a/filters.js
+++ b/filters.js
@@ -57,7 +57,7 @@ const filterByDirection = (data, type, direction) => {
   if (!_.includes(validDirectionTypes, direction)) {
     return data;
   }
-  const direction_id = (direction === 'outbound') ? '1' : '0';
+  const direction_id = (direction === 'outbound') ? 1 : 0;
   const filtered = _.filter(data.entity, (record) => {
     const trip_id = record[typeToKey(type)].trip.trip_id;
     return (direction_id === tripsIndexed[trip_id].direction_id);


### PR DESCRIPTION
In the last PR, I added options to the way the csv files are being parsed, which caused the direction_id to be stored as an int instead of a string. This changes the filter so it looks for an int instead of a string.