### PR TITLE
Add postgres database, query schedule to determine bus delays

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,0 +1,81 @@
+"use strict";
+const _ = require('lodash');
+const pg = require('pg');
+const format = require('pg-format');
+const moment = require('moment');
+
+const dbConfig = {
+  database: 'ripta'
+};
+
+const pool = new pg.Pool(dbConfig);
+
+const query = (sql) => {
+  const cleanedQuery = format(sql);
+
+  return new Promise((resolve, reject) => {
+    pool.query(cleanedQuery, (err, result) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(result.rows);
+      }
+    });
+  });
+};
+
+const getScheduledArrivalTS = (trip_id, stop_id) => {
+  const sql = `SELECT arrival_time, departure_time FROM stop_times WHERE stop_id = ${stop_id} AND trip_id = ${trip_id}`;
+  return query(sql).then((result) => {
+    if (result.length > 0) {
+      return parseInt(moment(result[0].arrival_time, 'HH:mm:ss').format('X'), 10);
+    }
+    return null;
+  });
+};
+
+const getPredictedArrivalTimes = (trips) => {
+  return trips.map((trip) => {
+    const trip_id = _.get(trip, ['trip_update', 'trip', 'trip_id']);
+    const stops = _.get(trip, ['trip_update', 'stop_time_update']);
+    const firstStop = _.head(stops);
+    if (firstStop && firstStop.stop_id) {
+      const stop_id = _.head(stops).stop_id;
+      const predictedArrivalTS = _.get(firstStop, ['arrival', 'time'], null) || _.get(firstStop, ['departure', 'time'], null);
+      return {
+        trip_id,
+        stop_id,
+        predictedArrivalTS
+      };
+    }
+    else {
+     return {};
+    }
+  }).filter((trip) => !_.isEmpty(trip));
+};
+
+const getTripDelays = (trips) => {
+  const predictedArrivalTimes = getPredictedArrivalTimes(trips);
+  const predictedArrivalTimeQueries = predictedArrivalTimes.map(({trip_id, stop_id, predictedArrivalTS}) => {
+    return getScheduledArrivalTS(trip_id, stop_id).then((scheduledArrivalTS) => {
+      const delay = predictedArrivalTS - scheduledArrivalTS;
+      return {
+        trip_id,
+        delay
+      };
+    });
+  });
+
+  return Promise.all(predictedArrivalTimeQueries);
+};
+
+const mergeDelayData = (trips, delays) => {
+  return trips.map(trip => {
+    const trip_id = _.get(trip, ['trip_update', 'trip', 'trip_id']);
+    const thisTrip = _.find(delays, {trip_id});
+    const delay = _.has(thisTrip, 'delay') ? thisTrip.delay : 0;
+    return Object.assign(trip, {delay});
+  });
+};
+
+module.exports = {query, getTripDelays, mergeDelayData}

--- a/models.js
+++ b/models.js
@@ -1,0 +1,23 @@
+const pg = require('pg');
+const connectionString = process.env.DATABASE_URL || 'postgres://localhost:5432/ripta';
+const client = new pg.Client(connectionString);
+
+client.connect();
+
+const query = client.query(
+  `CREATE TABLE stop_times(
+    id SERIAL PRIMARY KEY,
+    trip_id INTEGER,
+    arrival_time VARCHAR(8),
+    departure_time VARCHAR(8),
+    stop_id INTEGER,
+    stop_sequence INTEGER,
+    pickup_type SMALLINT,
+    drop_off_type SMALLINT
+  )`
+);
+
+query.on('end', () => {
+  client.end();
+});
+

--- a/package.json
+++ b/package.json
@@ -15,9 +15,12 @@
     "express": "^4.14.0",
     "jsonfile": "^2.4.0",
     "lodash": "^4.16.4",
+    "moment": "^2.18.1",
     "moment-timezone": "^0.5.7",
     "nodemon": "^1.11.0",
     "path": "^0.12.7",
+    "pg": "6.4.0",
+    "pg-format": "1.0.4",
     "request": "^2.76.0"
   }
 }

--- a/public/index.htm
+++ b/public/index.htm
@@ -192,12 +192,12 @@
             if (update.arrival === null) {
               var atime = 'Departs ' + tsToTime(update.departure.time);
               var thisStop = getStopDetail(update.stop_id);
-              var delayStr = formatDelay(update.departure.delay);
+              var delayStr = formatDelay(trip.delay);
             }
             else {
               var atime = 'Arrives ' + tsToTime(update.arrival.time);
               var thisStop = getStopDetail(update.stop_id);
-              var delayStr = formatDelay(update.arrival.delay);
+              var delayStr = formatDelay(trip.delay);
             }
             html += '<td>' + atime + '</td>';
             html += '<td>' + thisStop+ '</td>';

--- a/public/index.htm
+++ b/public/index.htm
@@ -93,7 +93,7 @@
       }
       var delay = secondsInt/60;
       var modifier = (secondsInt < 0) ? "early" : "late"
-      return Math.abs(delay) + " min. " + modifier;
+      return Math.abs(delay) + " min " + modifier;
     }
 
     function loadStops() {
@@ -154,29 +154,33 @@
       var route_id = $('.select-route').val();
       var direction = $('input[name=direction]:checked').val();
       $.getJSON('/api/tripupdates/route/' + route_id + '/' + direction, function(trips){
-        displayTrips(sortTripsByTime(trips));
+        displayTrips(sortTripsByTime(trips), route_id);
         hideSpinner();
       });
     }
 
-    function displayTrips(trips) {
+    function displayTrips(trips, route_id) {
       var html = '';
       $('.last-updated').html('Updated ' + tsToTime(trips.header.timestamp));
       if (trips.entity.length <1) {
         html += 'RIPTA is not returning any data';
       }
       else {
+        var thisRoute = routesIndexed[route_id];
+        var thisRouteName = thisRoute.route_short_name + ' ' + thisRoute.route_long_name;
+        html +='<h4>' + thisRouteName + '</h4>';
         $.each(trips.entity, function(key, trip){
           var thisTrip = trip.trip_update.trip;
           var route_id = thisTrip.route_id;
           var title = "Route " + route_id;
           var trip_id = thisTrip.trip_id;
-          var startTime = "Start time: " + moment(thisTrip.start_time, 'HH-mm-ss').format('h:mma');
+          var startTime = moment(thisTrip.start_time, 'HH-mm-ss').format('h:mma');
           var description = getTripDetail(trip_id).trip_headsign;
           var direction_id = getTripDetail(trip_id).direction_id;
-          var direction = (direction_id === '0') ? 'Inbound' : 'Outbound';
+          var direction = (direction_id === '0') ? '<-' : '->';
+          var delayStr = formatDelay(trip.delay);
 
-          html += ['<div class="trip-heading" id="' + trip_id + '">', title, startTime, description, direction, '</div>'].join(' ');
+          html += ['<div class="trip-heading" id="' + trip_id + '">', startTime, description, direction, ': ', delayStr, '</div>'].join(' ');
           html += '<table class="trip-update table table-sm table-striped">';
           html += '<thead>';
           html += '<tr>';

--- a/public/index.htm
+++ b/public/index.htm
@@ -188,7 +188,8 @@
           html += '<tbody>';
 
           $.each(trip.trip_update.stop_time_update, function(key, update){
-            html += '<tr>';
+            var tooltip = 'trip_id: ' + trip_id + ', stop_id: ' + update.stop_id;
+            html += '<tr title="' + tooltip + '">';
             if (update.arrival === null) {
               var atime = 'Departs ' + tsToTime(update.departure.time);
               var thisStop = getStopDetail(update.stop_id);


### PR DESCRIPTION
This adds a postgres database with a single table called `stop_times` which contains the schedule for all RIPTA bus trips and their associated stops.  This PR adds a query to this new table to find out when  bus is scheduled to arrived and compares that time to the predicted arrival time provided by the RIPTA API. It then merges that delay value into the API response as a new key, `delay` for each trip.