### PR TITLE
Remove blank lines from RIPTA txt files

### DIFF
--- a/seed.sh
+++ b/seed.sh
@@ -7,6 +7,8 @@ rm *.txt
 curl -sS "${URL}" > file.zip && \
 unzip file.zip
 rm file.zip
+sed -i .bak '/^.$/d' *.txt  # removes blank lines
+rm *.bak
 
 psql \
   -d $DATABASE_URL \

--- a/static/stops.json
+++ b/static/stops.json
@@ -46057,8 +46057,5 @@
     "location_type": 0,
     "parent_station": "",
     "stop_associated_place": ""
-  },
-  {
-    "stop_id": ""
   }
 ]


### PR DESCRIPTION
This removes blank lines from the RIPTA text files. Without this change, the `copy` command in `seed.sql` to populate the Postegres tables fails if it encounters a blank line.