### PR TITLE
Add new endpoint to get all trips by stop id

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Response:
 ----------
 
 ```
-GET /api/trips/:routeId
+GET /api/trips/route/:routeId
 ```
 Returns all bus trips on a particular route. Can be filtered by direction (inbound or outbound), time of day, and stop.
 
@@ -113,7 +113,7 @@ Params
 
 Example:
 ```
-api/trips/60/?serviceDay=Weekday&startTime=17:00&endTime=18:00?directionId=0
+api/trips/route/60/?serviceDay=Weekday&startTime=17:00&endTime=18:00?directionId=0
 ```
 
 Response:

--- a/README.md
+++ b/README.md
@@ -137,6 +137,53 @@ Response:
 ]
 ```
 ----------
+
+```
+GET /api/trips/stop/:stopId
+```
+Returns all bus trips for a particular stop. Can be filtered by direction (inbound or outbound), time of day, and route.
+
+Params
+
+* stopID (required)
+* routeId
+* serviceDay: Weekday | Saturday | Sunday - default is 'Weekday'
+* directionId: 0 | 1 - default is both - 0 is inbound, 1 is outbound
+* startTime: HH:MM - default is all day
+* endTime: HH:MM - default is all day
+
+Example:
+```
+api/trips/stop/8530?serviceDay=Weekday&startTime=17:00&endTime=18:00?directionId=0
+```
+
+Response:
+```
+{
+  "stopId": "8530",
+  "trips": [
+    {
+      "trip_id": 2764503,
+      "service_id": "hsem1801-Weekday-1-SE2018-1111100",
+      "arrival_time": "17:04:00",
+      "departure_time": "17:04:00",
+      "stop_name": "BARRINGTON PARK&RIDE (WHITE CHURCH)",
+      "route_id": 60,
+      "trip_headsign": "PROVIDENCE via EAST MAIN"
+    },
+    {
+      "trip_id": 2764465,
+      "service_id": "hsem1801-Weekday-1-SE2018-1111100",
+      "arrival_time": "17:19:00",
+      "departure_time": "17:19:00",
+      "stop_name": "BARRINGTON PARK&RIDE (WHITE CHURCH)",
+      "route_id": 60,
+      "trip_headsign": "PROVIDENCE via WEST MAIN"
+    },
+    ...
+}
+```
+----------
 ```
 GET /api/trip/:tripId
 ```

--- a/db.js
+++ b/db.js
@@ -7,6 +7,8 @@ const get = require('lodash/get');
 const getTripsByRouteSql = require('./queries').getTripsByRouteSql;
 const getStopsByTripSql = require('./queries').getStopsByTripSql;
 const getTripScheduleSql = require('./queries').getTripScheduleSql;
+const getTripsByStopIdSql = require('./queries').getTripsByStopIdSql;
+
 
 const LOCAL_DB = 'localhost';
 const DATABASE = 'ripta';
@@ -72,6 +74,16 @@ const getStopsByTrip = (tripId) => {
   });
 };
 
+const getTripsByStopId = (params) => {
+  const sql = getTripsByStopIdSql(params);
+  return query(sql).then((result) => {
+    if (result.length > 0) {
+      return { stopId: params.stopId, trips: result };
+    }
+    console.warn('No trips found for stop: ', params.stopId);
+    return [];
+  });
+};
 
 const getTripSchedules = (trips) => {
   const scheduleQueries = trips.map(trip => {
@@ -95,5 +107,6 @@ module.exports = {
   query,
   getTripsByRoute,
   getStopsByTrip,
-  getTripSchedules
+  getTripSchedules,
+  getTripsByStopId
 };

--- a/index.js
+++ b/index.js
@@ -64,6 +64,24 @@ app.get('/api/trip/:tripId', (req, res) => {
     .catch((error) => console.log(error));
 });
 
+app.get('/api/trips/stop/:stopId', (req, res) => {
+  const params = {
+    stopId: req.params.stopId,
+    serviceDay: req.query.serviceDay,
+    directionId: req.query.directionId,
+    startTime: req.query.startTime,
+    endTime: req.query.endTime
+  };
+  console.log(params);
+  if (true) {
+    db.getTripsByStopId(params)
+      .then((trips) => res.json(trips))
+      .catch((error) => console.log(error));
+  } else {
+    res.sendStatus(422);
+  }
+});
+
 app.get('/api/trips/route/:routeId', (req, res) => {
   const params = {
     routeId: req.params.routeId,

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ app.get('/api/trip/:tripId', (req, res) => {
     .catch((error) => console.log(error));
 });
 
-app.get('/api/trips/:routeId', (req, res) => {
+app.get('/api/trips/route/:routeId', (req, res) => {
   const params = {
     routeId: req.params.routeId,
     stopId: req.query.stopId,

--- a/queries.js
+++ b/queries.js
@@ -46,6 +46,42 @@ const getTripsByRouteSql = (params) => {
   ORDER BY direction_id, departure_time;`;
 };
 
+// get all trips by route with optional params
+// params: routeId, serviceDay, directionId, stopId, startTime, endTime
+const getTripsByStopIdSql = (params) => {
+  const where = [];
+
+  if (!params.stopId) {
+    return null;
+  }
+  where.push(`stops.stop_id = ${params.stopId}`);
+
+  if (params.routeId) {
+    where.push(`stops.route_id = ${params.routeId}`);
+  }
+  if (params.serviceDay) {
+    where.push(`service_id LIKE '%${params.serviceDay}%'`);
+  } else {
+    where.push('service_id LIKE \'%Weekday%\''); // default to Weekday
+  }
+  if (params.directionId) {
+    where.push(`direction_id = ${params.directionId}`);
+  }
+  if (params.startTime) {
+    where.push(`departure_time >= '${formatStrAsTime(params.startTime)}'`);
+  }
+  if (params.endTime) {
+    where.push(`departure_time <= '${formatStrAsTime(params.endTime)}'`);
+  }
+
+  return `select trips.trip_id, service_id, arrival_time, departure_time,
+    stop_name, route_id, trips.trip_headsign from stop_times
+    left join stops on stop_times.stop_id = stops.stop_id
+    left join trips on stop_times.trip_id = trips.trip_id
+    WHERE ${where.join(' AND ')}
+    ORDER BY departure_time;`;
+};
+
 // all stops on a particular trip
 const getStopsByTripSql = (tripId) => {
   return `SELECT stops.stop_id, stop_name, departure_time, arrival_time, stop_sequence
@@ -74,6 +110,7 @@ module.exports = {
   getTripsByRouteSql,
   getStopsByTripSql,
   getRoutesByStopSql,
-  getTripScheduleSql
+  getTripScheduleSql,
+  getTripsByStopIdSql
 };
 


### PR DESCRIPTION
This adds a new endpoint to get all trips by stop id.
The new endpoint is:
`/api/trips/stop/:stopId`

To accomodate this new endpoint, a current endpoint needed to be changed. 
`/api/trips/:routeId` is now `/api/trips/route/:routeId`
